### PR TITLE
Refactoring Page class removing TODO

### DIFF
--- a/notebook/static/auth/js/loginmain.js
+++ b/notebook/static/auth/js/loginmain.js
@@ -3,7 +3,7 @@
 
 define(['jquery', 'base/js/namespace', 'base/js/page'], function($, IPython, page) {
     function login_main() {
-      var page_instance = new page.Page();
+      var page_instance = new page.Page('div#header', 'div#site');
       $('button#login_submit').addClass("btn btn-default");
       page_instance.show();
       $('input#password_input').focus();

--- a/notebook/static/auth/js/logoutmain.js
+++ b/notebook/static/auth/js/logoutmain.js
@@ -3,7 +3,7 @@
 
 define(['base/js/namespace', 'base/js/page'], function(IPython, page) {
     function logout_main() {
-        var page_instance = new page.Page();
+        var page_instance = new page.Page('div#header', 'div#site');
         page_instance.show();
 
         IPython.page = page_instance;

--- a/notebook/static/base/js/page.js
+++ b/notebook/static/base/js/page.js
@@ -49,7 +49,7 @@ define([
          * The header and site divs start out hidden to prevent FLOUC.
          * Main scripts should call this method after styling everything.
          */
-         this.header_div_element.css('display','block');
+        this.header_div_element.css('display','block');
     };
 
     Page.prototype.show_site = function () {

--- a/notebook/static/base/js/page.js
+++ b/notebook/static/base/js/page.js
@@ -7,7 +7,17 @@ define([
 ], function($, events){
     "use strict";
 
-    var Page = function () {
+    var Page = function (header_div_selector, site_div_selector) {
+        /**
+        * Constructor
+        *
+        * Parameters
+        * header_div_selector: string
+        * site_div_selector: string
+        */
+        this.header_div_element = $(header_div_selector);
+        this.site_div_element = $(site_div_selector);
+
         this.bind_events();
     };
 
@@ -38,18 +48,16 @@ define([
         /**
          * The header and site divs start out hidden to prevent FLOUC.
          * Main scripts should call this method after styling everything.
-         * TODO: selector are hardcoded, pass as constructor argument
          */
-        $('div#header').css('display','block');
+         this.header_div_element.css('display','block');
     };
 
     Page.prototype.show_site = function () {
         /**
          * The header and site divs start out hidden to prevent FLOUC.
          * Main scripts should call this method after styling everything.
-         * TODO: selector are hardcoded, pass as constructor argument
          */
-        $('div#site').css('display', 'block');
+        this.site_div_element.css('display', 'block');
         this._resize_site();
     };
 

--- a/notebook/static/edit/js/main.js
+++ b/notebook/static/edit/js/main.js
@@ -35,7 +35,7 @@ require([
         console.warn(err);
     }
     
-    page = new page.Page();
+    page = new page.Page('div#header', 'div#site');
 
     var base_url = utils.get_body_data('baseUrl');
     var file_path = utils.get_body_data('filePath');

--- a/notebook/static/notebook/js/main.js
+++ b/notebook/static/notebook/js/main.js
@@ -99,7 +99,7 @@ require([
 
     // Instantiate the main objects
     
-    var page = new page.Page();
+    var page = new page.Page('div#header', 'div#site');
     var pager = new pager.Pager('div#pager', {
         events: events});
     var acts = new actions.init();

--- a/notebook/static/terminal/js/main.js
+++ b/notebook/static/terminal/js/main.js
@@ -18,7 +18,7 @@ require([
     ){
     "use strict";
     requirejs(['custom/custom'], function() {});
-    page = new page.Page();
+    page = new page.Page('div#header', 'div#site');
 
     var common_options = {
         base_url : utils.get_body_data("baseUrl"),

--- a/notebook/static/tree/js/main.js
+++ b/notebook/static/tree/js/main.js
@@ -75,7 +75,7 @@ require([
 
     // Instantiate the main objects
 
-    page = new page.Page();
+    page = new page.Page('div#header', 'div#site');
 
     var session_list = new sesssionlist.SesssionList($.extend({
         events: events},


### PR DESCRIPTION
While we were investigating the technical debt of the project me and @joined  spotted TODOs comments for some hardcoded selectors in the [page.js](https://github.com/jupyter/notebook/blob/666ecbf35c3310335a3c8c182e8f53441c991c14/notebook/static/base/js/page.js) file. Therefore, we refactored the constructor of class Page to accept two arguments.