### PR TITLE
Add pandoc to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ env:
     - GROUP=js/services
     - GROUP=js/tree
 
+addons:
+    apt_packages:
+        - pandoc
+
 before_install:
     - pip install --upgrade pip
     - pip install --upgrade setuptools wheel nose coverage codecov


### PR DESCRIPTION
While investigating testing debt, I realized that some tests are not run by Travis because they require pandoc which is not installed. This also results in a lower test coverage. I changed the Travis configuration file so that pandoc is installed in the initial install process.